### PR TITLE
Remove package type, default to library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2022-11-16
+
+- Fix package type, use Composer default of "library" instead of "project"
+
 ## [0.1.0] - 2022-11-16
 
 - Initial creation of the package

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,5 @@
       "@lint",
       "@phpunit"
     ]
-  },
-  "type": "project"
+  }
 }


### PR DESCRIPTION
This fixes a bug in Packagist where it tells you to install via creating a project instead of `composer require`.