### PR TITLE
Remove 'posts_where' filter after task run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2022-12-23
+
+- Remove `posts_where` filter after task is run.
+
 ## [0.1.1] - 2022-11-16
 
 - Fix package type, use Composer default of "library" instead of "project"

--- a/src/class-bulk-task.php
+++ b/src/class-bulk-task.php
@@ -243,5 +243,8 @@ class Bulk_Task {
 
 		// Re-enable automatic behavior turned off earlier.
 		$this->after_run();
+
+		// Remove filter after task run. Prevents double filtering the query if you're instantiating the class multiple times.
+		remove_filter( 'posts_where', [ $this, 'filter__posts_where' ], 9999 );
 	}
 }


### PR DESCRIPTION
This PR removes the filter for an object when the task is complete. This prevents residual callbacks in the `posts_where` hook stack after a task is complete.