### PR TITLE
Feature: Add support for term queries

### DIFF
--- a/src/class-bulk-task.php
+++ b/src/class-bulk-task.php
@@ -8,6 +8,7 @@
 namespace Alley\WP_Bulk_Task;
 
 use Alley\WP_Bulk_Task\Progress\Progress;
+use WP_Term_Query;
 use WP_Query;
 
 /**
@@ -39,7 +40,14 @@ class Bulk_Task {
 	protected int $min_id;
 
 	/**
-	 * Store the current WP_Query object hash for bulk tasks.
+	 * Store the current query object for bulk tasks.
+	 *
+	 * @var mixed
+	 */
+	protected string $query;
+
+	/**
+	 * Store the current query object hash for bulk tasks.
 	 *
 	 * @var string
 	 */
@@ -130,7 +138,7 @@ class Bulk_Task {
 	}
 
 	/**
-	 * Manipulate the WHERE clause of a bulk task query to paginate by ID.
+	 * Manipulate the WHERE clause of a bulk task post query to paginate by ID.
 	 *
 	 * This checks the object hash to ensure that we don't manipulate any other
 	 * queries that might run during a bulk task.
@@ -158,6 +166,135 @@ class Bulk_Task {
 	}
 
 	/**
+	 * Manipulate the WHERE clause of a bulk task term query to batch by ID.
+	 *
+	 * This checks the object hash to ensure that we don't manipulate any other
+	 * queries that might run during a bulk task.
+	 *
+	 * @link https://github.com/WordPress/wordpress-develop/blob/6.1/src/wp-includes/class-wp-term-query.php#L731
+	 *
+	 * @param array $clauses Associative array of the clauses for the query.
+	 * @return string Filtered array with our batching added to the WHERE clause.
+	 */
+	public function filter__terms_where( $clauses ) {
+		if ( ! empty( $this->query ) && spl_object_hash( $this->query ) === $this->object_hash ) {
+			global $wpdb;
+
+			$clauses['where'] .= sprintf(
+				' AND %s.term_id > %d AND %s.term_id <= %d %s',
+				$wpdb->terms,
+				$this->min_id,
+				$wpdb->terms,
+				$this->min_id + $this->stepping,
+				$where
+			);
+		}
+
+		return $clauses;
+	}
+
+	/**
+	 * Loop through any number of objects efficiently with a callback, and output
+	 * the progress.
+	 *
+	 * @param array    $args Array of args to pass to query.
+	 * @param callable $callable Callback function to invoke for each object.
+	 *                           The callable will be passed an object of the
+	 *                           specified type.
+	 * @param string   $object_type Type of object to query.
+	 */
+	public function run( array $args, callable $callable, string $object_type = 'wp_post' ): void {
+		if ( ! method_exists( $this, "run_${object_type}_query" ) ) {
+			return;
+		}
+
+		call_user_func( [ $this, "run_${object_type}_query" ], $args, $callable );
+	}
+
+	/**
+	 * Loop through any number of terms efficiently with a callback, and output
+	 * the progress.
+	 *
+	 * @param array    $args {
+	 *     WP_Term_Query args. Some have overridden defaults, and some are fixed.
+	 *     Anything not mentioned below will operate as normal.
+	 *
+	 *     @type bool   $count                  Always false.
+	 *     @type string $order                  Always 'ASC'.
+	 *     @type string $orderby                Always 'term_id'.
+	 *     @type int    $number                 Defaults to 100.
+	 *     @type bool   $update_term_meta_cache Always false.
+	 * }
+	 * @param callable $callable Callback function to invoke for each post.
+	 *                           The callable will be passed a post object.
+	 */
+	public function run_wp_term_query( array $args, callable $callable ): void {
+		global $wpdb;
+
+		// Apply default arguments.
+		$args = wp_parse_args(
+			$args,
+			[
+				'number' => 100,
+			],
+		);
+
+		// Force some arguments and don't let them get overridden.
+		$args['count']                  = false;
+		$args['order']                  = 'ASC';
+		$args['orderby']                = 'term_id';
+		$args['update_term_meta_cache'] = false;
+
+		// Ensure stepping is the larger of the configured value and number.
+		$this->stepping = max( $this->stepping, $args['number'] );
+
+		// Set the min ID from the cursor.
+		$this->min_id = $this->cursor->get();
+
+		// Set the max ID from the database.
+		$this->max_id = $wpdb->get_var( 'SELECT MAX(term_id) FROM ' . $wpdb->terms ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		// Handle batching.
+		add_filter( 'terms_clauses', [ $this, 'filter__terms_where' ], 9999, 1 );
+
+		// Turn off some automatic behavior that would slow down the process.
+		$this->before_run();
+
+		// All systems go.
+		while ( $this->min_id < $this->max_id ) {
+			// Build the query object, but don't run it without the object hash.
+			$this->query = new WP_Term_Query();
+
+			// Store the unique object hash to ensure we only filter this query.
+			$this->object_hash = spl_object_hash( $this->query );
+
+			// Run the query.
+			$this->query->query( $args );
+
+			// Fork for results vs. not.
+			if ( ! empty( $this->query->terms ) ) {
+				// Invoke the callable over every term.
+				array_walk( $this->query->terms, $callable );
+
+				// Update our min ID for the next query.
+				$this->min_id = end( $this->query->terms )->term_id;
+			} else {
+				// No results found in the block of terms, so skip ahead.
+				$this->min_id += $this->stepping;
+			}
+
+			// Actions to run after each batch of results.
+			$this->after_batch();
+		}
+
+		// Re-enable automatic behavior turned off earlier.
+		$this->after_run();
+
+		// Remove filter after task run. Prevents double filtering the query if you're instantiating the class multiple times.
+		remove_filter( 'terms_clauses', [ $this, 'filter__terms_where' ], 9999 );
+	}
+
+	/**
 	 * Loop through any number of posts efficiently with a callback, and output
 	 * the progress.
 	 *
@@ -178,7 +315,7 @@ class Bulk_Task {
 	 * @param callable $callable Callback function to invoke for each post.
 	 *                           The callable will be passed a post object.
 	 */
-	public function run( array $args, callable $callable ): void {
+	public function run_wp_post_query( array $args, callable $callable ): void {
 		global $wpdb;
 
 		// Apply default arguments.

--- a/src/class-bulk-task.php
+++ b/src/class-bulk-task.php
@@ -42,7 +42,7 @@ class Bulk_Task {
 	 * Store the current query object for bulk tasks. Used when filtering the
 	 * WHERE clause and the query object is not provided in the filter.
 	 *
-	 * @var object
+	 * @var object|WP_Query|WP_Term_Query
 	 */
 	protected object $query;
 
@@ -143,8 +143,10 @@ class Bulk_Task {
 	 * This checks the object hash to ensure that we don't manipulate any other
 	 * queries that might run during a bulk task.
 	 *
-	 * @param  string   $where The WHERE clause of the query.
-	 * @param  WP_Query $query The WP_Query instance (passed by reference).
+	 * @global WP_Query $wp_query WordPress Query object.
+	 *
+	 * @param string   $where The WHERE clause of the query.
+	 * @param WP_Query $query The WP_Query instance (passed by reference).
 	 *
 	 * @return string WHERE clause with our pagination added.
 	 */
@@ -212,6 +214,8 @@ class Bulk_Task {
 	 * Loop through any number of terms efficiently with a callback, and output
 	 * the progress.
 	 *
+	 * @global WP_Query $wp_query WordPress Query object.
+	 *
 	 * @param array    $args {
 	 *     WP_Term_Query args. Some have overridden defaults, and some are fixed.
 	 *     Anything not mentioned below will operate as normal.
@@ -247,7 +251,7 @@ class Bulk_Task {
 		$this->min_id = $this->cursor->get();
 
 		// Set the max ID from the database.
-		$this->max_id = $wpdb->get_var( 'SELECT MAX(term_taxonomy_id) FROM ' . $wpdb->term_taxonomy ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$this->max_id = (int) $wpdb->get_var( 'SELECT MAX(term_taxonomy_id) FROM ' . $wpdb->term_taxonomy ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		// Handle batching.
 		add_filter( 'terms_clauses', [ $this, 'filter__terms_where' ], 9999 );
@@ -292,6 +296,8 @@ class Bulk_Task {
 	/**
 	 * Loop through any number of posts efficiently with a callback, and output
 	 * the progress.
+	 *
+	 * @global WP_Query $wp_query WordPress Query object.
 	 *
 	 * @param array    $args {
 	 *     WP_Query args. Some have overridden defaults, and some are fixed.
@@ -338,7 +344,7 @@ class Bulk_Task {
 		$this->min_id = $this->cursor->get();
 
 		// Set the max ID from the database.
-		$this->max_id = $wpdb->get_var( 'SELECT MAX(ID) FROM ' . $wpdb->posts ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$this->max_id = (int) $wpdb->get_var( 'SELECT MAX(ID) FROM ' . $wpdb->posts ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		// Disable ElasticPress or VIP Search integration by default.
 		add_filter( 'ep_skip_query_integration', '__return_true', 100 );

--- a/src/class-bulk-task.php
+++ b/src/class-bulk-task.php
@@ -42,9 +42,9 @@ class Bulk_Task {
 	/**
 	 * Store the current query object for bulk tasks.
 	 *
-	 * @var mixed
+	 * @var object
 	 */
-	protected string $query;
+	protected object $query;
 
 	/**
 	 * Store the current query object hash for bulk tasks.

--- a/src/trait-bulk-task-side-effects.php
+++ b/src/trait-bulk-task-side-effects.php
@@ -5,7 +5,7 @@
  * @package alleyinteractive/wp-bulk-task
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace Alley\WP_Bulk_Task;
 

--- a/tests/class-test-post-bulk-task.php
+++ b/tests/class-test-post-bulk-task.php
@@ -1,19 +1,21 @@
 <?php
 /**
- * Alley\WP_Bulk_Task Tests: Test_Bulk_Task class
+ * Alley\WP_Bulk_Task Tests: Test_Post_Bulk_Task class
  *
  * @package alleyinteractive/wp-bulk-task
  */
 
 use Alley\WP_Bulk_Task\Bulk_Task;
+use Mantle\Testing\Concerns\Refresh_Database;
 use Mantle\Testkit\Test_Case;
 
 /**
- * Tests for the Bulk_Task class.
+ * Tests for the Test_Post_Bulk_Task class.
  *
  * @package alleyinteractive/wp-bulk-task
  */
-class Test_Bulk_Task extends Test_Case {
+class Test_Post_Bulk_Task extends Test_Case {
+	use Refresh_Database;
 
 	/**
 	 * Stores an array of created post IDs used in tests.
@@ -51,11 +53,12 @@ class Test_Bulk_Task extends Test_Case {
 			[
 				'post_type' => 'post',
 			],
-			function ( $post ) {
+			function ( WP_Post $post ): void {
 				$post->post_content = str_replace( 'apple', 'banana', $post->post_content );
 				wp_update_post( $post );
 			}
 		);
+
 		$this->assertEquals( 'banana', get_post( $this->post_ids[0] )->post_content );
 		$this->assertEquals( 'apple', get_post( $this->post_ids[1] )->post_content );
 	}
@@ -66,11 +69,12 @@ class Test_Bulk_Task extends Test_Case {
 	public function test_full_run(): void {
 		( new Bulk_Task( 'test_run' ) )->run(
 			[],
-			function ( $post ) {
+			function ( WP_Post $post ): void {
 				$post->post_content = str_replace( 'apple', 'banana', $post->post_content );
 				wp_update_post( $post );
 			}
 		);
+
 		$this->assertEquals( 'banana', get_post( $this->post_ids[0] )->post_content );
 		$this->assertEquals( 'banana', get_post( $this->post_ids[1] )->post_content );
 	}
@@ -83,11 +87,12 @@ class Test_Bulk_Task extends Test_Case {
 		$bulk_task->cursor->set( $this->post_ids[0] );
 		$bulk_task->run(
 			[],
-			function ( $post ) {
+			function ( WP_Post $post ): void {
 				$post->post_content = str_replace( 'apple', 'banana', $post->post_content );
 				wp_update_post( $post );
 			}
 		);
+
 		$this->assertEquals( 'apple', get_post( $this->post_ids[0] )->post_content );
 		$this->assertEquals( 'banana', get_post( $this->post_ids[1] )->post_content );
 	}

--- a/tests/class-test-term-bulk-task.php
+++ b/tests/class-test-term-bulk-task.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Alley\WP_Bulk_Task Tests: Test_Term_Bulk_Task class
+ *
+ * @package alleyinteractive/wp-bulk-task
+ */
+
+use Alley\WP_Bulk_Task\Bulk_Task;
+use Mantle\Testing\Concerns\Refresh_Database;
+use Mantle\Testkit\Test_Case;
+
+/**
+ * Tests for the Test_Term_Bulk_Task class.
+ *
+ * @package alleyinteractive/wp-bulk-task
+ */
+class Test_Term_Bulk_Task extends Test_Case {
+	use Refresh_Database;
+
+	/**
+	 * Stores an array of created term IDs used in tests.
+	 *
+	 * @var int[]
+	 */
+	private array $term_ids;
+
+	/**
+	 * Actions to be taken before each function in this class is run.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->term_ids = [
+			self::factory()->category->create(
+				[
+					'name' => 'apple',
+				]
+			),
+			self::factory()->tag->create(
+				[
+					'name' => 'apple',
+				]
+			),
+		];
+	}
+
+	/**
+	 * Tests the run function on a filtered set of terms.
+	 */
+	public function test_filtered_run(): void {
+		( new Bulk_Task( 'test_filtered_term_run' ) )->run(
+			[
+				'taxonomy'   => 'category',
+				'hide_empty' => false,
+			],
+			function ( WP_Term $term ): void {
+				wp_update_term( $term->term_id, $term->taxonomy, [ 'name' => 'banana' ] );
+			},
+			'wp_term'
+		);
+
+		$this->assertEquals( 'banana', get_term( $this->term_ids[0] )->name );
+	}
+
+	/**
+	 * Tests the run function on a full set of terms.
+	 */
+	public function test_full_run(): void {
+		( new Bulk_Task( 'test_term_run' ) )->run(
+			[
+				'taxonomy'   => [ 'category', 'post_tag' ],
+				'hide_empty' => false,
+			],
+			function ( WP_Term $term ): void {
+				wp_update_term( $term->term_id, $term->taxonomy, [ 'name' => 'banana' ] );
+			},
+			'wp_term'
+		);
+
+		$this->assertEquals( 'banana', get_term( $this->term_ids[0] )->name );
+		$this->assertEquals( 'banana', get_term( $this->term_ids[1] )->name );
+	}
+
+	/**
+	 * Tests the resume function based on the cursor position in the database.
+	 */
+	public function test_resumed_run(): void {
+		$bulk_task = new Bulk_Task( 'test_resumed_run' );
+		$bulk_task->cursor->set( $this->term_ids[0] );
+		$bulk_task->run(
+			[
+				'taxonomy'   => [ 'category', 'post_tag' ],
+				'hide_empty' => false,
+			],
+			function ( WP_Term $term ): void {
+				wp_update_term( $term->term_id, $term->taxonomy, [ 'name' => 'banana' ] );
+			},
+			'wp_term'
+		);
+
+		$this->assertEquals( 'apple', get_term( $this->term_ids[0] )->name );
+		$this->assertEquals( 'banana', get_term( $this->term_ids[1] )->name );
+	}
+}


### PR DESCRIPTION
* Adds support for term queries in bulk tasks.
* Accepts an optional `$object_type` arg for the `run()` method. When `wp_term` is supplied as the arg, `WP_Term_Query` is used for bulk tasks. Defaults to `WP_Query`.
* Uses `term_taxonomy_id` rather than `term_id` for the stepping intervals. This supports more performant queries for sites that do not have 1:1 `term_taxonomy_id` and `term_id` values and may have a large `term_id` range.