### PR TITLE
Add null progress bar

### DIFF
--- a/src/progress/class-null-progress-bar.php
+++ b/src/progress/class-null-progress-bar.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Alley\WP_Bulk_Task\Progress: Null_Progress_Bar Class
+ *
+ * @package alleyinteractive/wp-bulk-task
+ */
+
+namespace Alley\WP_Bulk_Task\Progress;
+
+/**
+ * No-op progress bar.
+ *
+ * @package alleyinteractive/wp-bulk-task
+ */
+class Null_Progress_Bar implements Progress {
+	/**
+	 * Sets the current value of the progress tracker.
+	 *
+	 * @param int $current The new current value for the progress tracker.
+	 */
+	public function set_current( int $current ): void {
+		// Nothing.
+	}
+
+	/**
+	 * Tells the progress tracker that it is finished.
+	 */
+	public function set_finished(): void {
+		// Nothing.
+	}
+
+	/**
+	 * Define the finish line for the progress tracker.
+	 *
+	 * @param int $total The total to set.
+	 */
+	public function set_total( int $total ): void {
+		// Nothing.
+	}
+}


### PR DESCRIPTION
`Bulk_Task` allows the progress bar to be omitted, but because `Progress` is an interface, it's also possible to implement the [null object pattern](https://en.wikipedia.org/wiki/Null_object_pattern). I'd like to be able to use a null progress bar to be able to still use dependency injection in my codebase even when I don't want a progress bar to appear. For example:

```
new Bulk_Task(
	'audit-blocks',
	get_flag_value( $assoc_args, 'verbose', false )
		? new PHP_CLI_Progress_Bar( 'Bulk Task: audit-blocks' )
		: new Null_Progress_Bar(),
);
```

However, since not all codebases rely on DI, I haven't changed the nullable nature of the `Progress` parameter.