### PR TITLE
Fix logic to reset runtime cache when using Object Cache Pro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2023-12-13
+
+- Add `Null_Progress_Bar`.
+- Fix logic to reset runtime cache when using Object Cache Pro. 
+
 ## [0.1.2] - 2022-12-23
 
 - Remove `posts_where` filter after task is run.


### PR DESCRIPTION
Object Cache Pro, the caching plugin recommended by Pantheon, includes its own interface with a `::flush_runtime()` method that clears the in-memory cache. 

The default method of resetting the cache in `\Alley\WP_Bulk_Task\Bulk_Task::after_batch()` relies on access to the `WP_Object_Cache::$cache` property, which isn't made accessible by Object Cache Pro, so the attempt to write to it generates an error.