### PR TITLE
Github Action: increase the supported matrix

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -11,3 +11,5 @@ on:
 jobs:
   coding-standards:
     uses: alleyinteractive/.github/.github/workflows/php-coding-standards.yml@main
+    with:
+      php: '8.3'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,8 @@ jobs:
   php-tests:
     strategy:
       matrix:
-        php: [8.0]
-        wordpress: ["latest"]
+        php: [8.0, 8.1, 8.2, 8.3]
+        wordpress: ['latest']
         multisite: [true, false]
     uses: alleyinteractive/.github/.github/workflows/php-tests.yml@main
     with:


### PR DESCRIPTION
As titled.

We don't run those tests frequently. So having a more broad matrix makes sense and it is a safe "investment".