### PR TITLE
Disable common integrations

### DIFF
--- a/src/class-bulk-task.php
+++ b/src/class-bulk-task.php
@@ -16,7 +16,6 @@ use WP_Query;
  * @package alleyinteractive/wp-bulk-task
  */
 class Bulk_Task {
-
 	/**
 	 * The cursor associated with this bulk task.
 	 *

--- a/src/class-bulk-task.php
+++ b/src/class-bulk-task.php
@@ -207,6 +207,9 @@ class Bulk_Task {
 		// Set the max ID from the database.
 		$this->max_id = $wpdb->get_var( 'SELECT MAX(ID) FROM ' . $wpdb->posts ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
+		// Disable ElasticPress or VIP Search integration by default.
+		add_filter( 'ep_skip_query_integration', '__return_true', 100 );
+
 		// Handle pagination.
 		add_filter( 'posts_where', [ $this, 'filter__posts_where' ], 9999, 2 );
 
@@ -245,5 +248,8 @@ class Bulk_Task {
 
 		// Remove filter after task run. Prevents double filtering the query if you're instantiating the class multiple times.
 		remove_filter( 'posts_where', [ $this, 'filter__posts_where' ], 9999 );
+
+		// Remove filter after task run.
+		remove_filter( 'ep_skip_query_integration', '__return_true', 100 );
 	}
 }

--- a/src/trait-bulk-task-side-effects.php
+++ b/src/trait-bulk-task-side-effects.php
@@ -20,7 +20,6 @@ trait Bulk_Task_Side_Effects {
 	 * Halt integrations and date changes when updating a post.
 	 */
 	protected function pause_side_effects(): void {
-		add_filter( 'ep_skip_query_integration', '__return_true', 100 );
 		add_filter( 'apple_news_skip_push', '__return_true', 100 );
 		add_filter( 'apple_news_should_post_autopublish', '__return_false', 100 );
 		add_filter( 'pp_notification_status_change', '__return_false', 100 );
@@ -32,7 +31,6 @@ trait Bulk_Task_Side_Effects {
 	 * Resume integrations and date changes when updating a post.
 	 */
 	protected function resume_side_effects(): void {
-		remove_filter( 'ep_skip_query_integration', '__return_true', 100 );
 		remove_filter( 'apple_news_skip_push', '__return_true', 100 );
 		remove_filter( 'apple_news_should_post_autopublish', '__return_false', 100 );
 		remove_filter( 'pp_notification_status_change', '__return_false', 100 );

--- a/src/trait-bulk-task-side-effects.php
+++ b/src/trait-bulk-task-side-effects.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Alley\Bulk_Task: Bulk_Task_Side_Effects trait
+ *
+ * @package alleyinteractive/wp-bulk-task
+ */
+
+declare(strict_types=1);
+
+namespace Alley\WP_Bulk_Task;
+
+/**
+ * A trait that disables side effects for bulk tasks.
+ *
+ * @package alleyinteractive/wp-bulk-task
+ */
+trait Bulk_Task_Side_Effects {
+
+	/**
+	 * Halt integrations and date changes when updating a post.
+	 */
+	protected function pause_side_effects(): void {
+		add_filter( 'ep_skip_query_integration', '__return_true', 100 );
+		add_filter( 'apple_news_skip_push', '__return_true', 100 );
+		add_filter( 'apple_news_should_post_autopublish', '__return_false', 100 );
+		add_filter( 'pp_notification_status_change', '__return_false', 100 );
+		add_filter( 'pp_notification_editorial_comment', '__return_false', 100 );
+		add_filter( 'wp_insert_post_data', [ $this, 'revert_post_modified_date' ], 10, 2 );
+	}
+
+	/**
+	 * Resume integrations and date changes when updating a post.
+	 */
+	protected function resume_side_effects(): void {
+		remove_filter( 'ep_skip_query_integration', '__return_true', 100 );
+		remove_filter( 'apple_news_skip_push', '__return_true', 100 );
+		remove_filter( 'apple_news_should_post_autopublish', '__return_false', 100 );
+		remove_filter( 'pp_notification_status_change', '__return_false', 100 );
+		remove_filter( 'pp_notification_editorial_comment', '__return_false', 100 );
+		remove_filter( 'wp_insert_post_data', [ $this, 'revert_post_modified_date' ], 10, 2 );
+	}
+
+	/**
+	 * Revert post modified date to date before post update.
+	 *
+	 * @param array $data    An array of slashed, sanitized, and processed post data.
+	 * @param array $postarr An array of sanitized (and slashed) but otherwise unmodified post data.
+	 * @return array Array of filtered post data.
+	 */
+	public function revert_post_modified_date( $data, $postarr ): array {
+		if ( empty( $data['post_modified'] ) || empty( $data['post_modified_gmt'] ) || empty( $postarr['post_modified'] ) || empty( $postarr['post_modified_gmt'] ) ) {
+			return $data;
+		}
+
+		$data['post_modified']     = $postarr['post_modified'];
+		$data['post_modified_gmt'] = $postarr['post_modified_gmt'];
+
+		return $data;
+	}
+}


### PR DESCRIPTION
- Disable common Elasticsearch integrations (ElasticPress or VIP Search) by default. See #3 
- A new trait, `Bulk_Task_Side_Effects`, to optionally disable common integrations

Here is an example:
```php

class Command extends WPCOM_VIP_CLI_Command {
    use Bulk_Task_Side_Effects;

    /**
     * Command description.
     *
     * ## OPTIONS
     *
     * [--dry-run]
     * : Resets the cursor before starting the command.
     */
    public function example_command( $args, $assoc_args ) {
        $this->pause_side_effects();

        // Optionally handle `--rewind`, `--from-scratch`, or user input here.
        $bulk_task->run(
            [ /* WP_Query arguments */ ],
            function( $post ) use ( $dry_run ) {
                $new_value = str_replace( 'apple', 'banana', $post->post_content );
                if ( $dry_run ) {
                    WP_CLI::log( 'Old post_content: ' . $post->post_content );
                    WP_CLI::log( 'New post_content: ' . $new_value );
                } else {
                    $post->post_content = $new_value;
                    wp_update_post( $post );
                }
            }
        );

        $this->resume_side_effects();
    }
}
```