### PR TITLE
Stop the `Cursor` from autoloading its option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unpublished
+
+### Changed
+
+- Stop `Cursor` option from autoloading its option.
+- Fixed incorrect usage of `@global`.
+- Improve typecasting of the `filter__terms_where` and `filter__posts_where` methods.
+- Support for `declare( strict_types=1 );`, to return any PHP errors.
+
 ## [0.2.1] - 2024-01-18
 
 ### Changed

--- a/src/class-bulk-task.php
+++ b/src/class-bulk-task.php
@@ -143,14 +143,13 @@ class Bulk_Task {
 	 * This checks the object hash to ensure that we don't manipulate any other
 	 * queries that might run during a bulk task.
 	 *
-	 * @global WP_Query $wp_query WordPress Query object.
+	 * @global wpdb $wpdb WordPress database abstraction object.
 	 *
 	 * @param string   $where The WHERE clause of the query.
 	 * @param WP_Query $query The WP_Query instance (passed by reference).
-	 *
 	 * @return string WHERE clause with our pagination added.
 	 */
-	public function filter__posts_where( $where, $query ) {
+	public function filter__posts_where( $where, $query ): string {
 		if ( spl_object_hash( $query ) === $this->object_hash ) {
 			global $wpdb;
 
@@ -178,9 +177,15 @@ class Bulk_Task {
 	 * @link https://github.com/WordPress/wordpress-develop/blob/6.1/src/wp-includes/class-wp-term-query.php#L731
 	 *
 	 * @param array $clauses Associative array of the clauses for the query.
-	 * @return string Filtered array with our batching added to the WHERE clause.
+	 * @return array Filtered array with our batching added to the WHERE clause.
 	 */
-	public function filter__terms_where( $clauses ) {
+	public function filter__terms_where( $clauses ): array {
+
+		// Reset if not an array.
+		if ( ! is_array( $clauses ) ) {
+			$clauses = [];
+		}
+
 		if ( ! empty( $this->query ) && spl_object_hash( $this->query ) === $this->object_hash ) {
 			$clauses['where'] .= sprintf(
 				' AND tt.term_taxonomy_id > %d AND tt.term_taxonomy_id <= %d',
@@ -214,7 +219,7 @@ class Bulk_Task {
 	 * Loop through any number of terms efficiently with a callback, and output
 	 * the progress.
 	 *
-	 * @global WP_Query $wp_query WordPress Query object.
+	 * @global wpdb $wpdb WordPress database abstraction object.
 	 *
 	 * @param array    $args {
 	 *     WP_Term_Query args. Some have overridden defaults, and some are fixed.
@@ -297,7 +302,7 @@ class Bulk_Task {
 	 * Loop through any number of posts efficiently with a callback, and output
 	 * the progress.
 	 *
-	 * @global WP_Query $wp_query WordPress Query object.
+	 * @global wpdb $wpdb WordPress database abstraction object.
 	 *
 	 * @param array    $args {
 	 *     WP_Query args. Some have overridden defaults, and some are fixed.

--- a/src/class-cursor.php
+++ b/src/class-cursor.php
@@ -5,6 +5,8 @@
  * @package alleyinteractive/wp-bulk-task
  */
 
+declare( strict_types=1 );
+
 namespace Alley\WP_Bulk_Task;
 
 /**
@@ -53,10 +55,9 @@ class Cursor {
 	 * Sets the value for the cursor.
 	 *
 	 * @param int $value The new value for the cursor.
-	 *
 	 * @return bool True if the value was successfully set, false otherwise.
 	 */
 	public function set( int $value ): bool {
-		return update_option( $this->option_name, $value );
+		return update_option( $this->option_name, $value, 'no' );
 	}
 }

--- a/tests/class-test-cursor.php
+++ b/tests/class-test-cursor.php
@@ -5,6 +5,8 @@
  * @package alleyinteractive/wp-bulk-task
  */
 
+declare( strict_types=1 );
+
 use Alley\WP_Bulk_Task\Cursor;
 use Mantle\Testkit\Test_Case;
 
@@ -24,5 +26,39 @@ class Test_Cursor extends Test_Case {
 		$this->assertEquals( 1234, $cursor->get() );
 		$cursor->reset();
 		$this->assertEquals( 0, $cursor->get() );
+	}
+
+	/**
+	 * Tests that the cursor option is not autoloaded.
+	 *
+	 * @global wpdb $wpdb WordPress database abstraction object.
+	 */
+	public function test_curso_option_not_autoload(): void {
+		global $wpdb;
+
+		$option_name     = 'test-cursor';
+		$option_name_key = "bt_{$option_name}";
+
+		// Ensure the value is indeed empty.
+		$this->assertEmpty( get_option( $option_name_key ) );
+
+		$cursor = new Cursor( $option_name );
+		$this->assertEquals( 0, $cursor->get() );
+		$cursor->set( 1234 );
+
+		// Ensure the option is not autoloaded.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$option_autoloaded = $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", $option_name_key ) );
+		$this->assertNotEmpty( $option_autoloaded );
+		$this->assertSame( 'no', $option_autoloaded );
+
+		$this->assertEquals( 1234, $cursor->get() );
+		$cursor->reset();
+		$this->assertEquals( 0, $cursor->get() );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$option_autoloaded = $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", $option_name_key ) );
+
+		$this->assertNull( $option_autoloaded );
 	}
 }


### PR DESCRIPTION
- Stop `Cursor` option from autoloading its option.
- Fixed incorrect usage of `@global`.
- Improve typecasting of the `filter__terms_where` and `filter__posts_where` methods.
- Support for `declare( strict_types=1 );`, to return any PHP errors.

fixes #13 