### PR TITLE
Feature: add support for CSV files in bulk tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add support for CSV files.
+- Support for PHPStan.
+- Support for CSV files in bulk tasks.
+- Support for user queries.
 
 ## [0.2.2] - 2024-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - Unpublished
+
+### Added
+
+- Add support for CSV files.
+
 ## [0.2.2] - 2024-03-12
 
 ### Changed

--- a/src/class-bulk-task.php
+++ b/src/class-bulk-task.php
@@ -5,11 +5,15 @@
  * @package alleyinteractive/wp-bulk-task
  */
 
+declare( strict_types=1 );
+
 namespace Alley\WP_Bulk_Task;
 
 use Alley\WP_Bulk_Task\Progress\Progress;
 use WP_Term_Query;
 use WP_Query;
+use SplFileObject;
+use Exception;
 
 /**
  * A class that provides performant bulk task functionality.
@@ -84,6 +88,9 @@ class Bulk_Task {
 	 * helper functions if they exist, or falls back to a manual implementation if
 	 * not.
 	 *
+	 * @global wpdb $wpdb WordPress database abstraction object.
+	 * @global WP_Object_Cache $wp_object_cache Object cache global instance.
+	 *
 	 * @link https://github.com/Automattic/vip-go-mu-plugins/blob/develop/vip-helpers/vip-caching.php
 	 * @link https://github.com/Automattic/vip-go-mu-plugins/blob/develop/vip-helpers/vip-wp-cli.php
 	 */
@@ -125,7 +132,10 @@ class Bulk_Task {
 	 * Actions to take after a bulk task is run.
 	 */
 	protected function after_run(): void {
-		wp_defer_term_counting( false );
+		if ( function_exists( 'wp_defer_term_counting' ) ) {
+			wp_defer_term_counting( false );
+		}
+
 		$this->progress?->set_finished();
 	}
 
@@ -133,7 +143,10 @@ class Bulk_Task {
 	 * Actions to take before a bulk task is run.
 	 */
 	protected function before_run(): void {
-		wp_defer_term_counting( true );
+		if ( function_exists( 'wp_defer_term_counting' ) ) {
+			wp_defer_term_counting( true );
+		}
+
 		$this->progress?->set_total( $this->max_id );
 	}
 
@@ -216,6 +229,108 @@ class Bulk_Task {
 	}
 
 	/**
+	 * Loop through any number of rows in a CSV file efficiently with a callback, and output progress.
+	 *
+	 * @throws Exception If the CSV file does not exist or is not readable.
+	 *
+	 * @param array    $args {
+	 *     Args for the CSV query.
+	 *     @type string $csv    Path to the CSV file.
+	 *     @type int    $number Number of rows to clear cursor in each batch.
+	 * }
+	 * @param callable $callable Callback function to invoke for each row.
+	 *                           The callable will be passed a row array.
+	 */
+	public function run_csv_query( array $args, callable $callable ): void {
+
+		// Apply default arguments.
+		$args = wp_parse_args(
+			$args,
+			[
+				'csv'    => '',
+				'number' => 100,
+			],
+		);
+
+		// Ensure the CSV file exists and is readable.
+		if ( empty( $args['csv'] ) || ! is_readable( $args['csv'] ) ) {
+			throw new Exception( 'The CSV file does not exist or is not readable.' );
+		}
+
+		/**
+		 * If the CSV document was created or is read on a Legacy Macintosh computer,
+		 * help PHP detect line ending.
+		 *
+		 * @see https://php.watch/versions/8.1/auto_detect_line_endings-ini-deprecated
+		 */
+		if ( version_compare( PHP_VERSION, '8.1.0', '<' ) ) {
+			if ( ! ini_get( 'auto_detect_line_endings' ) ) {
+				ini_set( 'auto_detect_line_endings', '1' );
+			}
+		}
+
+		// It assumes that the file is encoded in UTF-8.
+		try {
+			$csv = new SplFileObject( $args['csv'], 'r' );
+		} catch ( Exception $e ) {
+			throw new Exception( $e->getMessage() ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+
+		// Set the CSV flags.
+		$csv->setFlags( SplFileObject::READ_CSV | SplFileObject::READ_AHEAD | SplFileObject::SKIP_EMPTY | SplFileObject::DROP_NEW_LINE );
+
+		// Set the min ID from the cursor.
+		$this->min_id = $this->cursor->get();
+
+		// Set the max ID from CSV file.
+		$csv->seek( PHP_INT_MAX );
+		$this->max_id = $csv->key();
+
+		// Turn off some automatic behavior that would slow down the process.
+		$this->before_run();
+
+		/**
+		 * We do not run rows in batches since the CSV file outputs all rows at once.
+		 *
+		 * But we need it for the cursor, progress to be updated, and resetting
+		 * the object cache.
+		 */
+		$batch_size = 0;
+
+		// All systems go.
+		foreach ( $csv as $row ) {
+			$line_number = $csv->key();
+
+			// Skip lines outside of the range.
+			if ( $line_number < $this->min_id || $line_number > $this->max_id ) {
+				continue;
+			}
+
+			if ( $batch_size < $args['number'] ) {
+				$batch_size++;
+			}
+
+			$callable( $row );
+
+			// Batch size reached, so update the cursor.
+			if ( 100 === $batch_size ) {
+				$batch_size = 0;
+
+				// Update our min ID for the next batch.
+				$this->min_id = $line_number;
+			}
+
+			$this->after_batch();
+		}
+
+		// Unset the CSV file. Required to close the file stream.
+		unset( $csv );
+
+		// Re-enable automatic behavior turned off earlier.
+		$this->after_run();
+	}
+
+	/**
 	 * Loop through any number of terms efficiently with a callback, and output
 	 * the progress.
 	 *
@@ -237,12 +352,7 @@ class Bulk_Task {
 		global $wpdb;
 
 		// Apply default arguments.
-		$args = wp_parse_args(
-			$args,
-			[
-				'number' => 0,
-			],
-		);
+		$args = wp_parse_args( $args, [ 'number' => 0 ] );
 
 		// Force some arguments and don't let them get overridden.
 		$args['order']                  = 'ASC';

--- a/src/class-bulk-task.php
+++ b/src/class-bulk-task.php
@@ -284,6 +284,8 @@ class Bulk_Task {
 	 * }
 	 * @param callable $callable Callback function to invoke for each row.
 	 *                           The callable will be passed a row array.
+	 *
+	 * @phpstan-param array<mixed> $args
 	 */
 	public function run_csv_query( array $args, callable $callable ): void {
 
@@ -386,13 +388,13 @@ class Bulk_Task {
 	 *
 	 *     @type string $order                  Always 'ASC'.
 	 *     @type string $orderby                Always 'term_id'.
-	 *     @type int    $number                 Defaults to 0 (all).
 	 *     @type bool   $update_term_meta_cache Always false.
+	 *     @type int    $number                 Defaults to 0 (all).
 	 * }
 	 * @param callable $callable Callback function to invoke for each post.
 	 *                           The callable will be passed a post object.
 	 *
-	 * @phpstan-param array{order: 'ASC', orderby: 'term_id', number: 0, update_term_meta_cache: false} $args
+	 * @phpstan-param array<mixed> $args
 	 */
 	public function run_wp_term_query( array $args, callable $callable ): void {
 		global $wpdb;

--- a/tests/class-test-csv-bulk-task.php
+++ b/tests/class-test-csv-bulk-task.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Alley\WP_Bulk_Task Tests: Test_CSV_Bulk_Task class
+ *
+ * @package alleyinteractive/wp-bulk-task
+ */
+
+declare( strict_types=1 );
+
+use Alley\WP_Bulk_Task\Bulk_Task;
+use Mantle\Testing\Concerns\Refresh_Database;
+use Mantle\Testkit\Test_Case;
+
+/**
+ * Tests for the Test_CSV_Bulk_Task class.
+ *
+ * @package alleyinteractive/wp-bulk-task
+ */
+class Test_CSV_Bulk_Task extends Test_Case {
+	use Refresh_Database;
+
+	/**
+	 * The CSV file path.
+	 *
+	 * @var string
+	 */
+	public $csv;
+
+	/**
+	 * Actions to be taken before each function in this class is run.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->csv = __DIR__ . '/csv-test.csv';
+	}
+
+	/**
+	 * Test the run function on a invalid CSV file.
+	 */
+	public function test_invalid_csv(): void {
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'The CSV file does not exist or is not readable.' );
+
+		( new Bulk_Task( 'test_invalid_csv' ) )->run(
+			[
+				'csv' => 'invalid.csv',
+			],
+			function (): void {},
+			'csv'
+		);
+	}
+
+	/**
+	 * Tests the run function on a valid CSV file.
+	 */
+	public function test_full_run(): void {
+		( new Bulk_Task( 'test_run' ) )->run(
+			[
+				'csv' => $this->csv,
+			],
+			function ( $row ): void {
+				self::factory()->post->create( [ 'post_title' => $row[1] ] );
+			},
+			'csv'
+		);
+
+		$posts = get_posts(); // @phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
+		$this->assertCount( 5, $posts );
+		$this->assertEquals( 'Hello', $posts[0]->post_title );
+		$this->assertEquals( 'Hiii', $posts[1]->post_title );
+		$this->assertEquals( 'Hi', $posts[2]->post_title );
+	}
+
+	/**
+	 * Tests the resume function based on the cursor position on the CSV file.
+	 */
+	public function test_resumed_run(): void {
+		$rows = [];
+
+		$bulk_task = new Bulk_Task( 'test_resumed_run' );
+		$bulk_task->cursor->set( 4 );
+		$bulk_task->run(
+			[
+				'csv' => $this->csv,
+			],
+			function ( $row ) use ( &$rows ): void {
+				$rows[] = $row;
+				self::factory()->post->create( [ 'post_title' => $row[1] ] );
+			},
+			'csv'
+		);
+
+		$this->assertCount( 1, $rows );
+		$this->assertEquals( 05, $rows[0][0] );
+		$this->assertEquals( 'Hello', $rows[0][1] );
+
+		$posts = get_posts(); // @phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
+		$this->assertCount( 1, $posts );
+		$this->assertEquals( 'Hello', $posts[0]->post_title );
+	}
+}

--- a/tests/csv-test.csv
+++ b/tests/csv-test.csv
@@ -1,0 +1,5 @@
+01,Hello,World
+02,Lorem,Ipsum
+03,Hi,Ipsum
+04,Hiii,Ipsum
+05,Hello,Ipsum


### PR DESCRIPTION
fixes #19 

I've tried to not add external libraries unless necessary. So this approach uses core PHP functionality. We can revisit this if it becomes necessary.