### PR TITLE
Move query from local variable

### DIFF
--- a/src/class-bulk-task.php
+++ b/src/class-bulk-task.php
@@ -523,21 +523,21 @@ class Bulk_Task {
 		// All systems go.
 		while ( $this->min_id < $this->max_id ) {
 			// Build the query object, but don't run it without the object hash.
-			$query = new WP_Query();
+			$this->query = new WP_Query();
 
 			// Store the unique object hash to ensure we only filter this query.
-			$this->object_hash = spl_object_hash( $query );
+			$this->object_hash = spl_object_hash( $this->query );
 
 			// Run the query.
-			$query->query( $args );
+			$this->query->query( $args );
 
 			// Fork for results vs. not.
-			if ( $query->have_posts() ) {
+			if ( $this->query->have_posts() ) {
 				// Invoke the callable over every post.
-				array_walk( $query->posts, $callable, $query );
+				array_walk( $this->query->posts, $callable, $this->query );
 
 				// Update our min ID for the next query.
-				$last_post    = end( $query->posts );
+				$last_post    = end( $this->query->posts );
 				$this->min_id = $last_post instanceof WP_Post ? $last_post->ID : 0;
 			} else {
 				// No results found in the block of posts, so skip ahead.


### PR DESCRIPTION
As titled.

That's the only callback that uses the local variable for holding the current query.