### PR TITLE
Issue-32: Skip Pushes to Apple News By Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unpublished
+
+### Changed
+
+- Disables Apple News pushes by default during run. No longer requires the use of the side effects trait.
+
 ## [0.3.0] - 2024-06-22
 
 ### Added

--- a/src/class-bulk-task.php
+++ b/src/class-bulk-task.php
@@ -133,6 +133,8 @@ class Bulk_Task {
 		}
 
 		$this->progress?->set_finished();
+		remove_filter( 'apple_news_skip_push', '__return_true', 100 );
+		remove_filter( 'apple_news_should_post_autopublish', '__return_false', 100 );
 	}
 
 	/**
@@ -144,6 +146,8 @@ class Bulk_Task {
 		}
 
 		$this->progress?->set_total( $this->max_id );
+		add_filter( 'apple_news_skip_push', '__return_true', 100 );
+		add_filter( 'apple_news_should_post_autopublish', '__return_false', 100 );
 	}
 
 	/**

--- a/src/trait-bulk-task-side-effects.php
+++ b/src/trait-bulk-task-side-effects.php
@@ -20,8 +20,6 @@ trait Bulk_Task_Side_Effects {
 	 * Halt integrations and date changes when updating a post.
 	 */
 	protected function pause_side_effects(): void {
-		add_filter( 'apple_news_skip_push', '__return_true', 100 );
-		add_filter( 'apple_news_should_post_autopublish', '__return_false', 100 );
 		add_filter( 'pp_notification_status_change', '__return_false', 100 );
 		add_filter( 'pp_notification_editorial_comment', '__return_false', 100 );
 		add_filter( 'wp_insert_post_data', [ $this, 'revert_post_modified_date' ], 10, 2 );
@@ -32,8 +30,6 @@ trait Bulk_Task_Side_Effects {
 	 * Resume integrations and date changes when updating a post.
 	 */
 	protected function resume_side_effects(): void {
-		remove_filter( 'apple_news_skip_push', '__return_true', 100 );
-		remove_filter( 'apple_news_should_post_autopublish', '__return_false', 100 );
 		remove_filter( 'pp_notification_status_change', '__return_false', 100 );
 		remove_filter( 'pp_notification_editorial_comment', '__return_false', 100 );
 		remove_filter( 'wp_insert_post_data', [ $this, 'revert_post_modified_date' ], 10 );


### PR DESCRIPTION
## Summary

- Fixes #32

This pull request addresses the issue described here: https://github.com/alleyinteractive/wp-bulk-task/issues/32, aiming to disable pushes to Apple News by default when running a bulk task and allowing this behavior to be overridden if updates need to be sent to Apple News.

## Description

Disable pushes to Apple News by default when running a bulk task. Allow this behavior to be overridden (so updates _can_ be sent to Apple News, if desired). This is achieved by skipping Apple News pushes by default.

## Use Case

When running a bulk task, updates performed to posts should not be automatically synced to Apple News because it can create a flood of requests and potentially result in rate-limiting.