### PR TITLE
Fix `Bulk_Task_Side_Effects` public method

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -25,7 +25,7 @@
 	<arg name="severity" value="1"/>
 
 	<!-- Check for cross-version support for PHP 8.0 and higher. -->
-	<config name="testVersion" value="8.0-"/>
+	<config name="testVersion" value="8.1-"/>
 
 	<!-- Ignore compatibility problems with WordPress versions below this value. -->
 	<config name="minimum_supported_wp_version" value="6.0"/>

--- a/src/trait-bulk-task-side-effects.php
+++ b/src/trait-bulk-task-side-effects.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Alley\WP_Bulk_Task;
 
+use Closure;
+
 /**
  * A trait that disables side effects for bulk tasks.
  *
@@ -17,15 +19,24 @@ namespace Alley\WP_Bulk_Task;
 trait Bulk_Task_Side_Effects {
 
 	/**
+	 * Stores the closure to revert the post modified date.
+	 *
+	 * @var Closure
+	 */
+	protected Closure $revert_post_modified_date_closure;
+
+	/**
 	 * Halt integrations and date changes when updating a post.
 	 */
 	protected function pause_side_effects(): void {
+		$this->revert_post_modified_date_closure = $this->revert_post_modified_date( ... );
+
 		add_filter( 'apple_news_skip_push', '__return_true', 100 );
 		add_filter( 'apple_news_should_post_autopublish', '__return_false', 100 );
 		add_filter( 'pp_notification_status_change', '__return_false', 100 );
 		add_filter( 'pp_notification_editorial_comment', '__return_false', 100 );
-		add_filter( 'wp_insert_post_data', [ $this, 'revert_post_modified_date' ], 10, 2 );
 		add_filter( 'ef_notification_status_change', '__return_false', 999 );
+		add_filter( 'wp_insert_post_data', $this->revert_post_modified_date_closure, 10, 2 );
 	}
 
 	/**
@@ -36,8 +47,10 @@ trait Bulk_Task_Side_Effects {
 		remove_filter( 'apple_news_should_post_autopublish', '__return_false', 100 );
 		remove_filter( 'pp_notification_status_change', '__return_false', 100 );
 		remove_filter( 'pp_notification_editorial_comment', '__return_false', 100 );
-		remove_filter( 'wp_insert_post_data', [ $this, 'revert_post_modified_date' ], 10 );
 		remove_filter( 'ef_notification_status_change', '__return_false', 999 );
+		if ( isset( $this->revert_post_modified_date_closure ) ) {
+			remove_filter( 'wp_insert_post_data', $this->revert_post_modified_date_closure, 10 );
+		}
 	}
 
 	/**
@@ -47,7 +60,7 @@ trait Bulk_Task_Side_Effects {
 	 * @param array $postarr An array of sanitized (and slashed) but otherwise unmodified post data.
 	 * @return array Array of filtered post data.
 	 */
-	public function revert_post_modified_date( $data, $postarr ): array {
+	protected function revert_post_modified_date( $data, $postarr ): array {
 		if ( empty( $data['post_modified'] ) || empty( $data['post_modified_gmt'] ) || empty( $postarr['post_modified'] ) || empty( $postarr['post_modified_gmt'] ) ) {
 			return $data;
 		}


### PR DESCRIPTION
Avoid the public `revert_post_modified_date` method to be considered as a valid command by WP-CLI