### PR TITLE
Issue-45: Support PHPStan 2.0 (feature/2.x)

### DIFF
--- a/.github/workflows/all-pr-tests.yml
+++ b/.github/workflows/all-pr-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - feature/2.x
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:

--- a/.github/workflows/all-pr-tests.yml
+++ b/.github/workflows/all-pr-tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - feature/2.x
+      - 2.x
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 [Unreleased]
+
+### Updated
+
+- PHPStan: upgraded to 2.0.
+
 ## 1.0.0 - 2024-08-13
 
 - Stable release.

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "alleyinteractive/alley-coding-standards": "^2.0",
     "mantle-framework/testkit": "^1.0",
     "php-stubs/wp-cli-stubs": "^2.10",
-    "szepeviktor/phpstan-wordpress": "^1.3",
+    "szepeviktor/phpstan-wordpress": "^2.0",
     "wp-cli/php-cli-tools": "^0.11"
   },
   "autoload-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,13 @@ parameters:
 	# Level 9 is the highest level
 	level: max
 
+	tips:
+		treatPhpDocTypesAsCertain: false
+
+	# Skip since it is not used internally: https://phpstan.org/blog/how-phpstan-analyses-traits
+	excludePaths:
+		- src/trait-bulk-task-side-effects.php
+
 	paths:
 		- src/
 

--- a/src/progress/class-php-cli-progress-bar.php
+++ b/src/progress/class-php-cli-progress-bar.php
@@ -29,6 +29,10 @@ class PHP_CLI_Progress_Bar extends \cli\progress\Bar implements Progress {
 	 * @param int $current The new current value for the progress tracker.
 	 */
 	public function set_current( int $current ): void {
+		if ( ! is_int( $this->_current ) ) {
+			$this->_current = 0;
+		}
+
 		$this->tick( $current - $this->_current );
 	}
 


### PR DESCRIPTION
### Summary

Fixes #45

This pull request adds support for PHPStan 2.0 as outlined in the issue.

### Changes

- Implemented compatibility with PHPStan 2.0.
- Updated the `szepeviktor/phpstan-wordpress` package version constraint in `composer.json` to require `^2.0`.
- Added a new unreleased version `2.0.0` to the `CHANGELOG.md` and documented the PHPStan 2.0 upgrade under this version.
- Updated PHPStan configuration:
  - Introduced the `tips` section with `treatPhpDocTypesAsCertain` set to `false` for more cautious analysis.
  - Added an `excludePaths` section to skip analysis of specific files.
- Enhanced type safety:
  - Added `@phpstan-var` annotations for improved static analysis.
  - Replaced loosely typed parameters with more explicit types.
- Added safeguards to ensure type integrity in methods such as `set_current` in the `class-php-cli-progress-bar.php` file.
- Included `phpcs:disable` comments to suppress specific PHPCS warnings where necessary.

### Testing

- Verified functionality with PHPStan 2.0 integration.
- Ensured no regressions with existing features.
- Confirmed that updated configurations and safeguards work as intended.

### Additional Notes

For more details, refer to the original issue: [Support PHPStan 2.0](https://github.com/alleyinteractive/wp-bulk-task/issues/45).