### PR TITLE
Issue-44: Support PHP 8.4 (feature/2.x)

### DIFF
--- a/.github/workflows/all-pr-tests.yml
+++ b/.github/workflows/all-pr-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - feature/2.x
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
@@ -17,7 +18,7 @@ jobs:
     # Define a matrix of PHP/WordPress versions to test against
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3, 8.4]
         wordpress: ["latest"]
     runs-on: ubuntu-latest
     # Cancel any existing runs of this workflow

--- a/.github/workflows/all-pr-tests.yml
+++ b/.github/workflows/all-pr-tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - feature/2.x
+      - 2.x
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -24,7 +24,7 @@
 	<!-- Set severity to 1 to see everything that isn't effectively turned off. -->
 	<arg name="severity" value="1"/>
 
-	<!-- Check for cross-version support for PHP 8.0 and higher. -->
+	<!-- Check for cross-version support for PHP 8.1 and higher. -->
 	<config name="testVersion" value="8.1-"/>
 
 	<!-- Ignore compatibility problems with WordPress versions below this value. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 [Unreleased]
+
+### Updated
+
+- CI: support PHP 8.4.
+
 ## 1.0.0 - 2024-08-13
 
 - Stable release.


### PR DESCRIPTION
### Summary

Support PHP 8.4. Fixes #44.

### Description

- Added support for PHP 8.4.
- Updated CI configuration to include PHP 8.4 in the test matrix.
- Adjusted GitHub Actions workflow to run on the `feature/2.x` branch.
- Updated `.phpcs.xml` configuration to ensure compatibility starting from PHP 8.1.
- Updated `CHANGELOG.md` to document CI support for PHP 8.4 under version `2.0.0`.

### Use Case

This change ensures compatibility with PHP 8.4 and maintains support for previous PHP versions starting from PHP 8.1. It also improves CI workflows by expanding branch and PHP version coverage.

### Testing Instructions

Please ensure all tests pass successfully. Verify compatibility with PHP 8.4 and confirm that the CI workflow runs as expected for the `feature/2.x` branch.