### PR TITLE
Issue-42: Provide a safe way to halt the bulk task (2.x)

### DIFF
--- a/src/class-bulk-task.php
+++ b/src/class-bulk-task.php
@@ -381,19 +381,22 @@ class Bulk_Task {
 
 			if ( false === $retval ) {
 				$this->min_id = $line_number;
+
+				$this->after_batch();
 				break;
 			}
 
+			// Batch size reached, so update the cursor.
 			if ( 100 === $batch_size ) {
-				// Batch size reached, so update the cursor.
 				$batch_size = 0;
 
 				// Update our min ID for the next batch.
 				$this->min_id = $line_number;
+
+				// Actions to run after each batch of results.
+				$this->after_batch();
 			}
 		}
-
-		$this->after_batch();
 
 		// Unset the CSV file. Required to close the file stream.
 		unset( $csv );


### PR DESCRIPTION
### Summary
Fixes #42

This pull request introduces functionality to safely halt a bulk task and resume it later from the same position in the database. This enhancement avoids the need to let the bulk task run unnecessarily or restart from the beginning when resuming.

### Description
Currently, once a bulk task begins, it processes the entire database, invoking the callable for each item. However, there is no built-in way to halt the task and resume later at the same position. This PR addresses that limitation by:
- Allowing the callable to return `false` to signal the task to halt early.
- Ensuring the cursor (`min_id`) is updated to reflect the last processed item when halting.
- Adding logic to cleanly pause execution while maintaining the integrity of after-task logic.

Additionally, unnecessary parameters in test methods have been removed to simplify the codebase, and new test cases have been introduced to validate the halt-and-resume functionality.

### Motivation and Context
This change is motivated by a real-world use case where a bulk task was designed to delete items from a database. The client requested the ability to stop after deleting a specific number of items to review the impact of the deletions before proceeding further. Previously, stopping the task early required letting the rest of the bulk task run unnecessarily or restarting it from the beginning, which was inefficient and error-prone.

### How Has This Been Tested?
- Unit tests:
  - A new test method, `test_halt_task`, was added to ensure the bulk task can be halted and resumed correctly.
  - Existing tests were updated to reflect the changes in callable behavior and cursor updates.
- Manual testing:
  - Tested with varying database sizes and callable implementations to ensure the feature works as expected.
  - Verified that halting and resuming maintains the correct position and state.

### Screenshots (if applicable)
N/A

### Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.