### PR TITLE
Issue-39: Allow an implementer-provided callback to be executed after each batch (2.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.0.0 [Unreleased]
 
+### Added
+
+- Allow an implementer-provided callback to be executed after each batch.
+
 ### Updated
 
 - PHPStan: upgraded to 2.0.

--- a/src/class-bulk-task.php
+++ b/src/class-bulk-task.php
@@ -67,13 +67,23 @@ class Bulk_Task {
 	protected string $object_hash;
 
 	/**
+	 * Callback to execute after each batch is processed.
+	 *
+	 * @var null|callable
+	 */
+	protected $after_batch_callback = null;
+
+	/**
 	 * Constructor. Accepts a unique key, which is used to keep track of the
 	 * cursor within the database.
 	 *
 	 * @param string    $key      A unique key for this bulk task, used to manage the cursor.
 	 * @param ?Progress $progress An object to handle progress updates as the task runs.
 	 */
-	public function __construct( public string $key, private ?Progress $progress = null ) {
+	public function __construct(
+		public string $key,
+		private ?Progress $progress = null,
+	) {
 		$this->cursor = new Cursor( $key );
 	}
 
@@ -134,6 +144,18 @@ class Bulk_Task {
 
 		// Update progress.
 		$this->progress?->set_current( $this->min_id );
+
+		// Execute the after batch callback if provided.
+		if ( is_callable( $this->after_batch_callback ) ) {
+			call_user_func(
+				$this->after_batch_callback,
+				[
+					'cursor' => $this->key,
+					'min_id' => $this->min_id,
+					'max_id' => $this->max_id,
+				]
+			);
+		}
 	}
 
 	/**
@@ -278,17 +300,22 @@ class Bulk_Task {
 	 *                               The callable will be passed an object of the
 	 *                               specified type.
 	 * @param string       $object_type Type of object to query.
+	 * @param ?callable    $after_batch_callback Optional. Callback to run after each batch is processed.
 	 */
-	public function run( array $args, callable $callable, string $object_type = 'wp_post' ): void {
-		if ( ! method_exists( $this, "run_{$object_type}_query" ) ) {
-			return;
-		}
-
+	public function run(
+		array $args,
+		callable $callable,
+		string $object_type = 'wp_post',
+		?callable $after_batch_callback = null,
+	): void {
 		$method_callback = [ $this, "run_{$object_type}_query" ];
 
 		if ( ! is_callable( $method_callback ) ) {
 			throw new \Exception( 'Invalid method callback.' );
 		}
+
+		// Set the user provided callback to run after each batch.
+		$this->after_batch_callback = $after_batch_callback;
 
 		call_user_func( $method_callback, $args, $callable );
 	}

--- a/src/class-bulk-task.php
+++ b/src/class-bulk-task.php
@@ -150,7 +150,7 @@ class Bulk_Task {
 			call_user_func(
 				$this->after_batch_callback,
 				[
-					'cursor' => $this->key,
+					'cursor' => $this->cursor,
 					'min_id' => $this->min_id,
 					'max_id' => $this->max_id,
 				]

--- a/tests/TestCursor.php
+++ b/tests/TestCursor.php
@@ -18,6 +18,7 @@ use Mantle\Testkit\Test_Case;
  * @package alleyinteractive/wp-bulk-task
  */
 class TestCursor extends Test_Case {
+
 	/**
 	 * Tests the cursor lifecycle (does not exist, created, updated, removed).
 	 */
@@ -33,7 +34,7 @@ class TestCursor extends Test_Case {
 	/**
 	 * Tests that the cursor option is not autoloaded.
 	 *
-	 * @global wpdb $wpdb WordPress database abstraction object.
+	 * @global \wpdb $wpdb WordPress database abstraction object.
 	 */
 	public function test_cursor_option_not_autoload(): void {
 		global $wpdb;

--- a/tests/TestUserBulkTask.php
+++ b/tests/TestUserBulkTask.php
@@ -131,7 +131,7 @@ class TestUserBulkTask extends Test_Case {
 			'wp_user',
 			function (): void {
 				// Revert the first user's role back to contributor.
-				new WP_User( $this->user_ids[0] )->set_role( 'contributor' );
+				( new WP_User( $this->user_ids[0] ) )->set_role( 'contributor' );
 			}
 		);
 

--- a/tests/TestUserBulkTask.php
+++ b/tests/TestUserBulkTask.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Alley\WP_Bulk_Task\Tests;
 
 use Alley\WP_Bulk_Task\Bulk_Task;
-use Mantle\Testing\Concerns\Refresh_Database;
 use Mantle\Testkit\Test_Case;
 use WP_User;
 
@@ -20,7 +19,6 @@ use WP_User;
  * @package alleyinteractive/wp-bulk-task
  */
 class TestUserBulkTask extends Test_Case {
-	use Refresh_Database;
 
 	/**
 	 * Stores an array of created user IDs used in tests.
@@ -117,5 +115,27 @@ class TestUserBulkTask extends Test_Case {
 		);
 
 		$this->assertInstanceOf( 'WP_User_Query', $query );
+	}
+
+	/**
+	 * Test custom after batch callback.
+	 *
+	 * @throws \Exception Thrown when invalid callback is used.
+	 */
+	public function test_custom_after_batch_callback(): void {
+		( new Bulk_Task( 'test_custom_after_batch_callback' ) )->run(
+			[],
+			function ( WP_User $user ): void {
+				$user->set_role( 'editor' );
+			},
+			'wp_user',
+			function (): void {
+				// Revert the first user's role back to contributor.
+				new WP_User( $this->user_ids[0] )->set_role( 'contributor' );
+			}
+		);
+
+		$this->assertEquals( [ 'contributor' ], get_user_by( 'ID', $this->user_ids[0] )->roles );
+		$this->assertEquals( [ 'editor' ], get_user_by( 'ID', $this->user_ids[1] )->roles );
 	}
 }


### PR DESCRIPTION
### Summary

This pull request introduces the ability to allow an implementer-provided callback to be executed after each batch in the `after_batch` function of the bulk task. Fixes #39. Closes #41.

### Description

The bulk task currently has an `after_batch` function, but it is not pluggable. This enhancement enables implementers to provide their own callbacks to be executed after each batch. The callback can be passed when the bulk task is being set up, allowing greater flexibility and customization. Additionally, several code improvements and updates were made to enhance readability and maintainability.

### Implementation Details

- Added a new protected property `$after_batch_callback` to the `Bulk_Task` class to store implementer-provided callbacks.
- Modified the constructor for improved readability by formatting parameters on separate lines.
- Removed the `Refresh_Database` trait from various test classes, including `TestPostBulkTask`, `TestTermBulkTask`, and `TestUserBulkTask`, as database resetting functionality is no longer required or is handled differently.
- Improved code readability with minor formatting updates, such as adding blank lines and updating PHPDoc comments for clarity.
- Updated documentation to reflect the new functionality and changes.

### Motivation and Context

This feature was requested to address the need for more customizable post-batch processing in bulk tasks. The context for this need arose from [this](https://l.alley.dev/030fb56ead) scenario encountered by Alley developers. This enhancement provides developers with the flexibility to implement their own logic in the `after_batch` process.

### How Has This Been Tested?

- Unit tests have been added to verify the functionality of the implementer-provided callback.
- Manual testing was performed to ensure the callback is executed correctly with the defined values.
- New test methods were introduced across test classes to ensure the overall correctness of the updated functionality.

### Screenshots (if applicable)

N/A

### Types of Changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.